### PR TITLE
feat: additional API endpoint which lists downstream apps associated with devices

### DIFF
--- a/business_application/api/serializers.py
+++ b/business_application/api/serializers.py
@@ -33,7 +33,7 @@ class BusinessApplicationSerializer(serializers.ModelSerializer):
 class BusinessApplicationSlimSerializer(serializers.ModelSerializer):
     class Meta:
         model = BusinessApplication
-         fields = [
+        fields = [
             'id',
             'name',
             'appcode',

--- a/business_application/api/serializers.py
+++ b/business_application/api/serializers.py
@@ -1,6 +1,5 @@
 from rest_framework import serializers
 from business_application.models import BusinessApplication
-from dcim.models import Device
 
 class BusinessApplicationSerializer(serializers.ModelSerializer):
     """
@@ -23,38 +22,7 @@ class BusinessApplicationSerializer(serializers.ModelSerializer):
             'delegate',
             'servicenow',
             'virtual_machines',  # Assumes virtual_machines is a ManyToMany field
-            'devices',
         ]
         extra_kwargs = {
             'virtual_machines': {'read_only': True},
-            'devices': {'read_only': True},
         }
-
-class BusinessApplicationSlimSerializer(serializers.ModelSerializer):
-    class Meta:
-        model = BusinessApplication
-        fields = [
-            'id',
-            'name',
-            'appcode',
-            'owner',
-            'delegate',
-            'servicenow',
-        ]
-
-class DeviceWithApplicationsSerializer(serializers.ModelSerializer):
-    business_applications = BusinessApplicationSlimSerializer(
-        many=True,
-        read_only=True
-    )
-
-    class Meta:
-        model = Device
-        fields = [
-            'id',
-            'name',
-            'site',
-            'device_type',
-            'serial',
-            'business_applications',
-        ]

--- a/business_application/api/serializers.py
+++ b/business_application/api/serializers.py
@@ -17,7 +17,9 @@ class BusinessApplicationSerializer(serializers.ModelSerializer):
             'delegate',
             'servicenow',
             'virtual_machines',  # Assumes virtual_machines is a ManyToMany field
+            'devices',
         ]
         extra_kwargs = {
             'virtual_machines': {'read_only': True},
+            'devices': {'read_only': True},
         }

--- a/business_application/api/serializers.py
+++ b/business_application/api/serializers.py
@@ -53,9 +53,8 @@ class DeviceWithApplicationsSerializer(serializers.ModelSerializer):
         fields = [
             'id',
             'name',
-            'region',
             'site',
             'device_type',
-            'serial_number',
+            'serial',
             'business_applications',
         ]

--- a/business_application/api/serializers.py
+++ b/business_application/api/serializers.py
@@ -29,3 +29,33 @@ class BusinessApplicationSerializer(serializers.ModelSerializer):
             'virtual_machines': {'read_only': True},
             'devices': {'read_only': True},
         }
+
+class BusinessApplicationSlimSerializer(serializers.ModelSerializer):
+    class Meta:
+        model = BusinessApplication
+         fields = [
+            'id',
+            'name',
+            'appcode',
+            'owner',
+            'delegate',
+            'servicenow',
+        ]
+
+class DeviceWithApplicationsSerializer(serializers.ModelSerializer):
+    business_applications = BusinessApplicationSlimSerializer(
+        many=True,
+        read_only=True
+    )
+
+    class Meta:
+        model = Device
+        fields = [
+            'id',
+            'name',
+            'region',
+            'site',
+            'device_type',
+            'serial_number',
+            'business_applications',
+        ]

--- a/business_application/api/serializers.py
+++ b/business_application/api/serializers.py
@@ -1,11 +1,17 @@
 from rest_framework import serializers
 from business_application.models import BusinessApplication
+from dcim.models import Device
 
 class BusinessApplicationSerializer(serializers.ModelSerializer):
     """
     Serializer for the BusinessApplication model.
     Provides representation for API interactions.
     """
+    devices = serializers.PrimaryKeyRelatedField(
+        many=True,
+        queryset=Device.objects.all()
+    )
+    
     class Meta:
         model = BusinessApplication
         fields = [

--- a/business_application/api/serializers.py
+++ b/business_application/api/serializers.py
@@ -6,11 +6,6 @@ class BusinessApplicationSerializer(serializers.ModelSerializer):
     Serializer for the BusinessApplication model.
     Provides representation for API interactions.
     """
-    devices = serializers.PrimaryKeyRelatedField(
-        many=True,
-        queryset=Device.objects.all()
-    )
-    
     class Meta:
         model = BusinessApplication
         fields = [

--- a/business_application/api/urls.py
+++ b/business_application/api/urls.py
@@ -1,8 +1,17 @@
 from rest_framework.routers import DefaultRouter
-from business_application.api.views import BusinessApplicationViewSet, DeviceWithApplicationsViewSet
+from business_application.api.views import BusinessApplicationViewSet, DeviceDownstreamAppsViewSet
 
 router = DefaultRouter()
 router.register(r'business-applications', BusinessApplicationViewSet, basename='businessapplication')
-router.register(r'devices-with-apps', DeviceWithApplicationsViewSet, basename='devicewithapps')
 
-urlpatterns = router.urls
+device_downstream_view = DeviceDownstreamAppsViewSet.as_view({
+    'get': 'downstream_applications'
+})
+
+urlpatterns = router.urls + [
+    path(
+        'devices/<int:pk>/downstream-applications/',
+        device_downstream_view,
+        name='device-downstream-applications'
+    )
+]

--- a/business_application/api/urls.py
+++ b/business_application/api/urls.py
@@ -4,6 +4,16 @@ from business_application.api.views import BusinessApplicationViewSet, DeviceDow
 
 router = DefaultRouter()
 router.register(r'business-applications', BusinessApplicationViewSet, basename='businessapplication')
-router.register(r'devices', DeviceDownstreamAppsViewSet, basename='devicedownstreamapps')
 
-urlpatterns = router.urls
+urlpatterns = router.urls + [
+    path(
+        'devices/downstream-applications/<int:pk>/',
+        DeviceDownstreamAppsViewSet.as_view({'get': 'retrieve'}),
+        name='device-downstream-applications-detail'
+    ),
+    path(
+        'devices/downstream-applications/',
+        DeviceDownstreamAppsViewSet.as_view({'get': 'list'}),
+        name='device-downstream-applications-list'
+    ),
+]

--- a/business_application/api/urls.py
+++ b/business_application/api/urls.py
@@ -5,3 +5,5 @@ from business_application.api.views import BusinessApplicationViewSet, DeviceDow
 router = DefaultRouter()
 router.register(r'business-applications', BusinessApplicationViewSet, basename='businessapplication')
 router.register(r'devices', DeviceDownstreamAppsViewSet, basename='devicedownstreamapps')
+
+urlpatterns = router.urls

--- a/business_application/api/urls.py
+++ b/business_application/api/urls.py
@@ -1,3 +1,4 @@
+from django.urls import path
 from rest_framework.routers import DefaultRouter
 from business_application.api.views import BusinessApplicationViewSet, DeviceDownstreamAppsViewSet
 

--- a/business_application/api/urls.py
+++ b/business_application/api/urls.py
@@ -1,7 +1,8 @@
 from rest_framework.routers import DefaultRouter
-from business_application.api.views import BusinessApplicationViewSet
+from business_application.api.views import BusinessApplicationViewSet, DeviceWithApplicationsViewSet
 
 router = DefaultRouter()
 router.register(r'business-applications', BusinessApplicationViewSet, basename='businessapplication')
+router.register(r'devices-with-apps', DeviceWithApplicationsViewSet, basename='devicewithapps')
 
 urlpatterns = router.urls

--- a/business_application/api/urls.py
+++ b/business_application/api/urls.py
@@ -4,15 +4,4 @@ from business_application.api.views import BusinessApplicationViewSet, DeviceDow
 
 router = DefaultRouter()
 router.register(r'business-applications', BusinessApplicationViewSet, basename='businessapplication')
-
-device_downstream_view = DeviceDownstreamAppsViewSet.as_view({
-    'get': 'downstream_applications'
-})
-
-urlpatterns = router.urls + [
-    path(
-        'devices/<int:pk>/downstream-applications/',
-        device_downstream_view,
-        name='device-downstream-applications'
-    )
-]
+router.register(r'devices', DeviceDownstreamAppsViewSet, basename='devicedownstreamapps')

--- a/business_application/api/views.py
+++ b/business_application/api/views.py
@@ -53,9 +53,8 @@ class DeviceDownstreamAppsViewSet(ModelViewSet):
             for termination in node.cabletermination_set.select_related('cable').prefetch_related('cable__a_terminations__device', 'cable__b_terminations__device'):
                 cable = termination.cable
                 for t in cable.a_terminations + cable.b_terminations:
-                    if hasattr(t, 'device') and t.device and t.device.id not in visited_ids:
+                    if hasattr(t, 'device') and t.device:
                         nodes.append(t.device)
-                        visited_ids.add(t.device.id)
 
         return apps
 

--- a/business_application/api/views.py
+++ b/business_application/api/views.py
@@ -62,8 +62,21 @@ class DeviceDownstreamAppsViewSet(ModelViewSet):
         return Response(serializer.data)
 
     def list(self, request):
-        all_apps = set()
-        for device in self.queryset:
-            all_apps.update(self._get_downstream_apps(device))
-        serializer = BusinessApplicationSerializer(all_apps, many=True, context={'request': request})
-        return Response(serializer.data)
+        name_filter = request.query_params.get('name')
+        devices = self.queryset
+    
+        if name_filter:
+            devices = devices.filter(name__icontains=name_filter)
+    
+        result = {}
+    
+        for device in devices:
+            apps = self._get_downstream_apps(device)
+            serializer = BusinessApplicationSerializer(apps, many=True, context={'request': request})
+    
+            result[device.id] = {
+                "name": device.name,
+                "applications": serializer.data
+            }
+    
+        return Response(result)

--- a/business_application/api/views.py
+++ b/business_application/api/views.py
@@ -37,38 +37,38 @@ class DeviceDownstreamAppsViewSet(ModelViewSet):
     permission_classes = [IsAuthenticated]
 
     @action(detail=True, methods=['get'], url_path='downstream-applications')
-def downstream_applications(self, request, pk=None):
-    device = self.get_object()
-    logger.info(f"Starting downstream traversal for device {device} (ID={device.id})")
-
-    apps = set()
-    nodes = [device]
-    visited_ids = set()
-    current = 0
-
-    while current < len(nodes):
-        node = nodes[current]
-        logger.info(f"Visiting device {node.name} (ID={node.id})")
-
-        # Collect apps
-        found_apps = BusinessApplication.objects.filter(
-            Q(devices=node) | Q(virtual_machines__device=node)
-        )
-        logger.info(f"Found {found_apps.count()} apps on device {node.name}")
-        apps.update(found_apps)
-
-        # Traverse cable connections
-        for termination in node.cabletermination_set.all():
-            cable = termination.cable
-
-            for t in cable.a_terminations + cable.b_terminations:
-                if hasattr(t, 'device') and t.device and t.device.id not in visited_ids:
-                    nodes.append(t.device)
-                    visited_ids.add(t.device.id)
-                    logger.info(f"Found connected device: {t.device.name} (ID={t.device.id})")
-
-        current += 1
-
-    serializer = BusinessApplicationSerializer(apps, many=True, context={'request': request})
-    logger.info(f"Returning {len(apps)} downstream apps for device {device.name} (ID={device.id})")
-    return Response(serializer.data)
+    def downstream_applications(self, request, pk=None):
+        device = self.get_object()
+        logger.info(f"Starting downstream traversal for device {device} (ID={device.id})")
+    
+        apps = set()
+        nodes = [device]
+        visited_ids = set()
+        current = 0
+    
+        while current < len(nodes):
+            node = nodes[current]
+            logger.info(f"Visiting device {node.name} (ID={node.id})")
+    
+            # Collect apps
+            found_apps = BusinessApplication.objects.filter(
+                Q(devices=node) | Q(virtual_machines__device=node)
+            )
+            logger.info(f"Found {found_apps.count()} apps on device {node.name}")
+            apps.update(found_apps)
+    
+            # Traverse cable connections
+            for termination in node.cabletermination_set.all():
+                cable = termination.cable
+    
+                for t in cable.a_terminations + cable.b_terminations:
+                    if hasattr(t, 'device') and t.device and t.device.id not in visited_ids:
+                        nodes.append(t.device)
+                        visited_ids.add(t.device.id)
+                        logger.info(f"Found connected device: {t.device.name} (ID={t.device.id})")
+    
+            current += 1
+    
+        serializer = BusinessApplicationSerializer(apps, many=True, context={'request': request})
+        logger.info(f"Returning {len(apps)} downstream apps for device {device.name} (ID={device.id})")
+        return Response(serializer.data)

--- a/business_application/api/views.py
+++ b/business_application/api/views.py
@@ -1,7 +1,9 @@
-from rest_framework.viewsets import ModelViewSet
+from rest_framework.viewsets import ModelViewSet, ReadOnlyModelViewSet
 from business_application.models import BusinessApplication
-from business_application.api.serializers import BusinessApplicationSerializer
+from business_application.api.serializers import BusinessApplicationSerializer, DeviceWithApplicationsSerializer
 from rest_framework.permissions import IsAuthenticated
+from dcim.models import Device
+
 
 class BusinessApplicationViewSet(ModelViewSet):
     """
@@ -23,3 +25,11 @@ class BusinessApplicationViewSet(ModelViewSet):
         if appcode:
             queryset = queryset.filter(appcode__iexact=appcode)
         return queryset
+
+class DeviceWithApplicationsViewSet(ReadOnlyModelViewSet):
+    """
+    API endpoint that lists Devices with their related Business Applications.
+    """
+    queryset = Device.objects.prefetch_related('business_applications').all()
+    serializer_class = DeviceWithApplicationsSerializer
+    permission_classes = [IsAuthenticated]

--- a/business_application/api/views.py
+++ b/business_application/api/views.py
@@ -31,7 +31,6 @@ class BusinessApplicationViewSet(ModelViewSet):
 
 class DeviceDownstreamAppsViewSet(ModelViewSet):
     queryset = Device.objects.all()
-    serializer_class = DeviceSerializer  # optional, not used by this action directly
     permission_classes = [IsAuthenticated]
 
     @action(detail=True, methods=['get'], url_path='downstream-applications')

--- a/business_application/api/views.py
+++ b/business_application/api/views.py
@@ -7,7 +7,7 @@ class BusinessApplicationViewSet(ModelViewSet):
     """
     API endpoint for managing BusinessApplication objects.
     """
-    queryset = BusinessApplication.objects.prefetch_related('virtual_machines').all()
+    queryset = BusinessApplication.objects.prefetch_related('virtual_machines', 'devices').all()
     serializer_class = BusinessApplicationSerializer
     permission_classes = [IsAuthenticated]
 

--- a/business_application/api/views.py
+++ b/business_application/api/views.py
@@ -11,7 +11,7 @@ class BusinessApplicationViewSet(ModelViewSet):
     """
     API endpoint for managing BusinessApplication objects.
     """
-    queryset = BusinessApplication.objects.prefetch_related('virtual_machines', 'devices').all()
+    queryset = BusinessApplication.objects.prefetch_related('virtual_machines').all()
     serializer_class = BusinessApplicationSerializer
     permission_classes = [IsAuthenticated]
 

--- a/business_application/api/views.py
+++ b/business_application/api/views.py
@@ -29,31 +29,46 @@ class BusinessApplicationViewSet(ModelViewSet):
         return queryset
 
 class DeviceDownstreamAppsViewSet(ModelViewSet):
+    """
+    API endpoint for listing downstream applications associated with devices.
+    """
     queryset = Device.objects.all()
     permission_classes = [IsAuthenticated]
 
     def _get_downstream_apps(self, device):
         apps = set()
+        seen_ids = set()
         nodes = [device]
-        visited_ids = {device.id}
-        current = 0
-
-        while current < len(nodes):
-            node = nodes[current]
-            found_apps = BusinessApplication.objects.filter(
+    
+        while nodes:
+            node = nodes.pop()
+            if node.id in seen_ids:
+                continue
+            seen_ids.add(node.id)
+    
+            apps.update(BusinessApplication.objects.filter(
                 Q(devices=node) | Q(virtual_machines__device=node)
+            ))
+    
+            terminations = node.cabletermination_set.select_related('cable').prefetch_related(
+                'cable__a_terminations__device',
+                'cable__b_terminations__device'
             )
-            apps.update(found_apps)
-
-            for termination in node.cabletermination_set.all():
+    
+            for termination in terminations:
                 cable = termination.cable
-                for t in cable.a_terminations + cable.b_terminations:
-                    if hasattr(t, 'device') and t.device and t.device.id not in visited_ids:
-                        nodes.append(t.device)
-                        visited_ids.add(t.device.id)
-
-            current += 1
-        return apps
+    
+                for t in cable.a_terminations.all():
+                    t_device = getattr(t, 'device', None)
+                    if t_device and t_device.id not in seen_ids:
+                        nodes.append(t_device)
+    
+                for t in cable.b_terminations.all():
+                    t_device = getattr(t, 'device', None)
+                    if t_device and t_device.id not in seen_ids:
+                        nodes.append(t_device)
+    
+        return list(apps)
 
     def retrieve(self, request, pk=None):
         device = self.get_object()
@@ -63,10 +78,16 @@ class DeviceDownstreamAppsViewSet(ModelViewSet):
 
     def list(self, request):
         name_filter = request.query_params.get('name')
+        limit = int(request.query_params.get('limit', 20))
+        offset = int(request.query_params.get('offset', 0))
+    
         devices = self.queryset
     
         if name_filter:
             devices = devices.filter(name__icontains=name_filter)
+    
+        total = devices.count()
+        devices = devices[offset:offset + limit]
     
         result = {}
     
@@ -79,4 +100,9 @@ class DeviceDownstreamAppsViewSet(ModelViewSet):
                 "applications": serializer.data
             }
     
-        return Response(result)
+        return Response({
+            "count": total,
+            "limit": limit,
+            "offset": offset,
+            "results": result
+        })

--- a/business_application/api/views.py
+++ b/business_application/api/views.py
@@ -1,6 +1,8 @@
-from rest_framework.viewsets import ModelViewSet, ReadOnlyModelViewSet
+from rest_framework.viewsets import ViewSet, ModelViewSet
+from rest_framework.decorators import action
+from rest_framework.response import Response
 from business_application.models import BusinessApplication
-from business_application.api.serializers import BusinessApplicationSerializer, DeviceWithApplicationsSerializer
+from business_application.api.serializers import BusinessApplicationSerializer
 from rest_framework.permissions import IsAuthenticated
 from dcim.models import Device
 
@@ -26,10 +28,40 @@ class BusinessApplicationViewSet(ModelViewSet):
             queryset = queryset.filter(appcode__iexact=appcode)
         return queryset
 
-class DeviceWithApplicationsViewSet(ReadOnlyModelViewSet):
-    """
-    API endpoint that lists Devices with their related Business Applications.
-    """
-    queryset = Device.objects.prefetch_related('business_applications').all()
-    serializer_class = DeviceWithApplicationsSerializer
-    permission_classes = [IsAuthenticated]
+class DeviceDownstreamAppsViewSet(ViewSet):
+    @action(detail=True, methods=['get'], url_path='downstream-applications')
+    def downstream_applications(self, request, pk=None):
+        try:
+            device = Device.objects.get(pk=pk)
+        except Device.DoesNotExist:
+            return Response({'error': 'Device not found'}, status=404)
+
+        name_filter = request.query_params.get('device_name')
+        apps = set()
+        visited = set()
+        nodes = [device]
+        current = 0
+
+        while current < len(nodes):
+            node = nodes[current]
+            visited.add(node)
+            current += 1
+
+            if name_filter and name_filter.lower() not in node.name.lower():
+                continue
+
+            apps.update(BusinessApplication.objects.filter(
+                Q(devices=node) |
+                Q(virtual_machines__device=node)
+            ))
+
+            for ct in node.cabletermination_set.all():
+                cable = ct.cable
+                for term in cable.a_terminations + cable.b_terminations:
+                    next_dev = getattr(term, 'device', None)
+                    if next_dev and next_dev not in visited and next_dev.role == node.role:
+                        nodes.append(next_dev)
+
+        serializer = BusinessApplicationSerializer(apps, many=True, context={'request': request})
+        permission_classes = [IsAuthenticated]
+        return Response(serializer.data)


### PR DESCRIPTION
Adding missing API endpoint which lists downstream apps associated with devices

Example usage:

curl -H "Authorization: Token <token>" \
     https://netbox-instance.com/api/plugins/business-application/devices/downstream-applications/{device_id}/

curl -H "Authorization: Token <token>" \
     "https://netbox-instance.com/api/plugins/business-application/devices/downstream-applications/?name={device_name}"

curl -H "Authorization: Token <token>" \
     "https://netbox-instance.com/api/plugins/business-application/devices/downstream-applications/?limit=10"

curl -H "Authorization: Token <token>" \
     "https://netbox-instance.com/api/plugins/business-application/devices/downstream-applications/?limit=10&offset=10"